### PR TITLE
Fix: set output AudioBitRate

### DIFF
--- a/output_setters.go
+++ b/output_setters.go
@@ -82,7 +82,7 @@ func (c *Command) AudioRate(v int) *Command {
 
 // AudioBitRate sets the audio bit rate
 func (c *Command) AudioBitRate(v int) *Command {
-	c.Args.output.audioRate = v
+	c.Args.output.audioBitrate = v
 
 	return c
 }


### PR DESCRIPTION
This PR fixes the [issue](https://github.com/scalarhq/go-fluent-ffmpeg/issues/13) with the AudioBitRate function. It was setting the output `audioRate` instead of `audioBitrate`. 