### PR TITLE
Fix: get audioBitrate instead of audioRate

### DIFF
--- a/output_getters.go
+++ b/output_getters.go
@@ -98,7 +98,7 @@ func (a *Args) GetAudioRate() []string {
 // GetAudioBitrate returns the arguments for bitrate
 func (a *Args) GetAudioBitrate() []string {
 	if a.output.audioBitrate != 0 {
-		return []string{"-b:a", fmt.Sprintf("%d", a.output.audioRate)}
+		return []string{"-b:a", fmt.Sprintf("%d", a.output.audioBitrate)}
 	}
 	return nil
 }

--- a/output_getters.go
+++ b/output_getters.go
@@ -97,7 +97,7 @@ func (a *Args) GetAudioRate() []string {
 
 // GetAudioBitrate returns the arguments for bitrate
 func (a *Args) GetAudioBitrate() []string {
-	if a.output.audioRate != 0 {
+	if a.output.audioBitrate != 0 {
 		return []string{"-b:a", fmt.Sprintf("%d", a.output.audioRate)}
 	}
 	return nil


### PR DESCRIPTION
This PR ensures we get audio bitrate instead of audio rate in output_getters file. Fixes the same [issue](https://github.com/scalarhq/go-fluent-ffmpeg/issues/13) as the one fixed here for output_setters.

## Test Proof

Code being tested:

```golang
package main

import (
	"fmt"
	"os"

	fluentffmpeg "github.com/modfy/fluent-ffmpeg"
)

func main() {
	Cmd := fluentffmpeg.NewCommand("").
		Options("-hide_banner").
		InputPath("./audio (1)_input.wav").
		OutputFormat("mp3").
		OutputLogs(os.Stdout).
		OutputPath("./audio.mp3").
		AudioBitRate(64000).
		AudioRate(22000)

	bitRate := Cmd.Args.GetAudioBitrate()
	sampleRate := Cmd.Args.GetAudioRate()
	fmt.Println(bitRate)
	fmt.Println(sampleRate)
}

```

Screenshots of the code to test and the output. Basically set the output bitrate and sample rate to 64000 and 22000 respectively.

Then fetched the same and printed out. Shows the correct settings.

### Before Changes - (using current release v0.1.0)

<img width="576" alt="Screenshot 2024-01-23 at 12 00 51 AM" src="https://github.com/scalarhq/go-fluent-ffmpeg/assets/6931892/1040e8fd-4b1e-4c7f-abda-37f526403a20">

You can see that it's only setting the `audioRate` and then getting `audioRate` as well because both setter and getter use `audioRate` instead of `audioBitrate`.

### After Changes

<img width="555" alt="Screenshot 2024-01-23 at 12 00 43 AM" src="https://github.com/scalarhq/go-fluent-ffmpeg/assets/6931892/71968373-620a-4a8d-a2e6-a898ad150904">

While I fixed the setter in the other PR (https://github.com/scalarhq/go-fluent-ffmpeg/pull/13), this PR fixes the getter as well.